### PR TITLE
Reduced bottom padding for headers

### DIFF
--- a/github-night.css
+++ b/github-night.css
@@ -199,7 +199,7 @@ h6 {
     color: #c9d1d9;
     font-family: "Nunito", sans-serif;
     font-weight: 400;
-    padding: 20px 0;
+    padding-top: 20px;
 }
 
 html {


### PR DESCRIPTION
It could be possible to enhance this gorgeous theme by reducing the bottom padding for the headers, so they can stay closer to their paragraph.

Here some screenshoots:

- Before:
<img width="394" alt="Screenshot 2021-03-17 at 11 52 41" src="https://user-images.githubusercontent.com/14147983/111456961-e28fbb00-8717-11eb-9d01-6c4b792cb50c.png">


- After: 
<img width="390" alt="Screenshot 2021-03-17 at 11 53 34" src="https://user-images.githubusercontent.com/14147983/111456928-dc014380-8717-11eb-9bb6-ff2b140b76c1.png">



